### PR TITLE
Задание 6.2

### DIFF
--- a/places/lib/ui/screen/sight_edit_screen.dart
+++ b/places/lib/ui/screen/sight_edit_screen.dart
@@ -123,6 +123,9 @@ class _SightEditScreenState extends State<SightEditScreen> {
       );
 
   // Фотографии мест.
+  // ListView для строки не очень подходит, т.к. занимает всё пространтсво
+  // по вертикали. Можно ограничить только явным указанием размера. В то время
+  // как SingleChildScrollView + Row подстраиваются под размер. Это удобнее.
   Widget _buildPhotoGallery() => SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: Row(


### PR DESCRIPTION
SingleChildScrollView + Column переделал в ListView раньше. Row переделывать не стал, т.к. для строки он не очень подходит, т.к. занимает всё пространство по вертикали. Можно ограничить только явным указанием размера. В то время как SingleChildScrollView + Row подстраиваются под размер. Это удобнее.